### PR TITLE
Add option to keep original property name casing

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/OriginalCSharpPropertyNameGenerator.cs
+++ b/src/NSwag.CodeGeneration.CSharp/OriginalCSharpPropertyNameGenerator.cs
@@ -1,0 +1,65 @@
+using NJsonSchema.CodeGeneration;
+using NJsonSchema.CodeGeneration.CSharp;
+
+namespace NSwag.CodeGeneration.CSharp
+{
+    /// <summary>
+    /// Generates property names without modifying their casing.
+    /// </summary>
+    public sealed class OriginalCSharpPropertyNameGenerator : IPropertyNameGenerator
+    {
+        private const string FirstPassChars = "\"'@?!$[]().=+|";
+#if NET8_0_OR_GREATER
+        private static readonly System.Buffers.SearchValues<char> _reservedFirstPassChars = System.Buffers.SearchValues.Create(FirstPassChars);
+#else
+        private static readonly char[] _reservedFirstPassChars = FirstPassChars.ToCharArray();
+#endif
+
+        private const string SecondPassChars = "*:-#&";
+#if NET8_0_OR_GREATER
+        private static readonly System.Buffers.SearchValues<char> _reservedSecondPassChars = System.Buffers.SearchValues.Create(SecondPassChars);
+#else
+        private static readonly char[] _reservedSecondPassChars = SecondPassChars.ToCharArray();
+#endif
+
+        /// <summary>
+        /// Returns the property name unchanged except for removing invalid characters.
+        /// </summary>
+        /// <param name="property">The JSON schema property.</param>
+        /// <returns>The generated name.</returns>
+        public string Generate(JsonSchemaProperty property)
+        {
+            var name = property.Name;
+
+            if (name.AsSpan().IndexOfAny(_reservedFirstPassChars) != -1)
+            {
+                name = name.Replace("\"", string.Empty)
+                    .Replace("'", string.Empty)
+                    .Replace("@", string.Empty)
+                    .Replace("?", string.Empty)
+                    .Replace("!", string.Empty)
+                    .Replace("$", string.Empty)
+                    .Replace("[", string.Empty)
+                    .Replace("]", string.Empty)
+                    .Replace("(", "_")
+                    .Replace(")", string.Empty)
+                    .Replace(".", "_")
+                    .Replace("=", "_")
+                    .Replace("+", "plus")
+                    .Replace("|", "_");
+            }
+
+            if (name.AsSpan().IndexOfAny(_reservedSecondPassChars) != -1)
+            {
+                name = name
+                    .Replace("*", "Star")
+                    .Replace(":", "_")
+                    .Replace("-", "_")
+                    .Replace("#", "_")
+                    .Replace("&", "And");
+            }
+
+            return name;
+        }
+    }
+}

--- a/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
+++ b/src/NSwag.Commands/Commands/CodeGeneration/OpenApiToCSharpCommandBase.cs
@@ -361,5 +361,15 @@ namespace NSwag.Commands.CodeGeneration
             get => Settings.CSharpGeneratorSettings.GenerateNullableReferenceTypes;
             set => Settings.CSharpGeneratorSettings.GenerateNullableReferenceTypes = value;
         }
+
+        [Argument(Name = "UseOriginalPropertyNames", IsRequired = false,
+            Description = "Specifies whether to keep the original casing of schema properties (default: false).")]
+        public bool UseOriginalPropertyNames
+        {
+            get => Settings.CSharpGeneratorSettings.PropertyNameGenerator is NSwag.CodeGeneration.CSharp.OriginalCSharpPropertyNameGenerator;
+            set => Settings.CSharpGeneratorSettings.PropertyNameGenerator = value
+                ? new NSwag.CodeGeneration.CSharp.OriginalCSharpPropertyNameGenerator()
+                : new CSharpPropertyNameGenerator();
+        }
     }
 }


### PR DESCRIPTION
## Summary
- add `OriginalCSharpPropertyNameGenerator` that does not change property casing
- expose new CLI argument `UseOriginalPropertyNames` to use the new generator

