### PR TITLE
Fix duplicate enum values case-insensitively

### DIFF
--- a/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBase.cs
+++ b/src/NSwag.CodeGeneration.CSharp/CSharpGeneratorBase.cs
@@ -10,6 +10,7 @@ using NJsonSchema;
 using NJsonSchema.CodeGeneration;
 using NJsonSchema.CodeGeneration.CSharp;
 using NSwag.CodeGeneration.CSharp.Models;
+using NSwag.CodeGeneration;
 
 namespace NSwag.CodeGeneration.CSharp
 {
@@ -100,6 +101,7 @@ namespace NSwag.CodeGeneration.CSharp
         /// <returns>The code artifact collection.</returns>
         protected override IEnumerable<CodeArtifact> GenerateDtoTypes()
         {
+            _document.RemoveCaseInsensitiveEnumDuplicates();
             var generator = new CSharpGenerator(_document, _settings.CSharpGeneratorSettings, _resolver);
             return generator.GenerateTypes();
         }

--- a/src/NSwag.CodeGeneration/EnumExtensions.cs
+++ b/src/NSwag.CodeGeneration/EnumExtensions.cs
@@ -62,15 +62,16 @@ namespace NSwag.CodeGeneration
             schema = schema.ActualSchema;
             if (schema.Enumeration?.Count > 1 && schema.Enumeration.All(e => e is string))
             {
-                var unique = new List<object>();
+                var uniqueValues = new List<string>();
                 var uniqueNames = new List<string?>();
                 var comparer = StringComparer.OrdinalIgnoreCase;
+
                 for (int i = 0; i < schema.Enumeration.Count; i++)
                 {
                     var value = (string)schema.Enumeration[i];
-                    if (!unique.Cast<string>().Any(u => comparer.Equals(u, value)))
+                    if (!uniqueValues.Any(v => comparer.Equals(v, value)))
                     {
-                        unique.Add(value);
+                        uniqueValues.Add(value);
                         if (schema.EnumerationNames?.Count > i)
                         {
                             uniqueNames.Add(schema.EnumerationNames[i]);
@@ -78,10 +79,10 @@ namespace NSwag.CodeGeneration
                     }
                 }
 
-                if (unique.Count != schema.Enumeration.Count)
+                if (uniqueValues.Count != schema.Enumeration.Count)
                 {
                     schema.Enumeration.Clear();
-                    foreach (var item in unique)
+                    foreach (var item in uniqueValues)
                     {
                         schema.Enumeration.Add(item);
                     }
@@ -94,6 +95,11 @@ namespace NSwag.CodeGeneration
                             schema.EnumerationNames.Add(name);
                         }
                     }
+                }
+
+                if (schema.EnumerationNames == null)
+                {
+                    schema.EnumerationNames = uniqueValues.ToList();
                 }
             }
 

--- a/src/NSwag.CodeGeneration/EnumExtensions.cs
+++ b/src/NSwag.CodeGeneration/EnumExtensions.cs
@@ -1,0 +1,124 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NJsonSchema;
+
+namespace NSwag.CodeGeneration
+{
+    internal static class EnumExtensions
+    {
+        public static void RemoveCaseInsensitiveEnumDuplicates(this OpenApiDocument document)
+        {
+            if (document == null)
+            {
+                return;
+            }
+
+            var visited = new HashSet<JsonSchema>();
+            foreach (var schema in document.Components.Schemas.Values)
+            {
+                RemoveCaseInsensitiveEnumDuplicates(schema, visited);
+            }
+
+            foreach (var path in document.Paths.Values)
+            {
+                foreach (var operation in path.ActualPathItem.ActualOperations.Values)
+                {
+                    foreach (var parameter in operation.ActualParameters)
+                    {
+                        RemoveCaseInsensitiveEnumDuplicates(parameter.ActualSchema, visited);
+                    }
+
+                    var requestBody = operation.ActualRequestBody;
+                    if (requestBody?.Content != null)
+                    {
+                        foreach (var content in requestBody.Content.Values)
+                        {
+                            RemoveCaseInsensitiveEnumDuplicates(content.Schema, visited);
+                        }
+                    }
+
+                    foreach (var response in operation.ActualResponses)
+                    {
+                        if (response.Value.Content != null)
+                        {
+                            foreach (var content in response.Value.Content.Values)
+                            {
+                                RemoveCaseInsensitiveEnumDuplicates(content.Schema, visited);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        private static void RemoveCaseInsensitiveEnumDuplicates(JsonSchema schema, HashSet<JsonSchema> visited)
+        {
+            if (schema == null || !visited.Add(schema))
+            {
+                return;
+            }
+
+            schema = schema.ActualSchema;
+            if (schema.Enumeration?.Count > 1 && schema.Enumeration.All(e => e is string))
+            {
+                var unique = new List<object>();
+                var uniqueNames = new List<string?>();
+                var comparer = StringComparer.OrdinalIgnoreCase;
+                for (int i = 0; i < schema.Enumeration.Count; i++)
+                {
+                    var value = (string)schema.Enumeration[i];
+                    if (!unique.Cast<string>().Any(u => comparer.Equals(u, value)))
+                    {
+                        unique.Add(value);
+                        if (schema.EnumerationNames?.Count > i)
+                        {
+                            uniqueNames.Add(schema.EnumerationNames[i]);
+                        }
+                    }
+                }
+
+                if (unique.Count != schema.Enumeration.Count)
+                {
+                    schema.Enumeration.Clear();
+                    foreach (var item in unique)
+                    {
+                        schema.Enumeration.Add(item);
+                    }
+
+                    if (schema.EnumerationNames != null)
+                    {
+                        schema.EnumerationNames.Clear();
+                        foreach (var name in uniqueNames)
+                        {
+                            schema.EnumerationNames.Add(name);
+                        }
+                    }
+                }
+            }
+
+            foreach (var property in schema.ActualProperties.Values)
+            {
+                RemoveCaseInsensitiveEnumDuplicates(property.ActualSchema, visited);
+            }
+
+            if (schema.Item != null)
+            {
+                RemoveCaseInsensitiveEnumDuplicates(schema.Item, visited);
+            }
+
+            if (schema.Items != null)
+            {
+                foreach (var item in schema.Items)
+                {
+                    RemoveCaseInsensitiveEnumDuplicates(item, visited);
+                }
+            }
+
+            if (schema.AdditionalPropertiesSchema != null)
+            {
+                RemoveCaseInsensitiveEnumDuplicates(schema.AdditionalPropertiesSchema, visited);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `EnumExtensions` to remove enum duplicates ignoring case
- use the extension when generating C# DTOs

## Testing
- ❌ `dotnet test --no-build` *(failed: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b96179fac832cbbb7fa0b701e6e8a